### PR TITLE
Adding Method to Switch Android back to MODE_NORMAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ To set the current audio mode, use the `setAudioMode` method:
     AudioToggle.setAudioMode(AudioToggle.SPEAKER);
     // or
     AudioToggle.setAudioMode(AudioToggle.EARPIECE);
+
+Android has the following additional options:
+
+    AudioToggle.setAudioMode(AudioToggle.NORMAL);
+    // and
+    AudioToggle.setAudioMode(AudioToggle.RINGTONE);

--- a/src/android/com/dooble/audiotoggle/AudioTogglePlugin.java
+++ b/src/android/com/dooble/audiotoggle/AudioTogglePlugin.java
@@ -40,6 +40,14 @@ public class AudioTogglePlugin extends CordovaPlugin {
 	    	audioManager.setMode(AudioManager.STREAM_MUSIC);
 	    	audioManager.setSpeakerphoneOn(true);
 	        return true;
+	    } else if (mode.equals("ringtone")) {        
+	    	audioManager.setMode(AudioManager.MODE_RINGTONE);
+	    	audioManager.setSpeakerphoneOn(false);
+	        return true; 
+	    } else if (mode.equals("normal")) {        
+	    	audioManager.setMode(AudioManager.MODE_NORMAL);
+	    	audioManager.setSpeakerphoneOn(false);
+	        return true;
 	    }
 	    
 	    return false;

--- a/src/ios/AudioTogglePlugin.m
+++ b/src/ios/AudioTogglePlugin.m
@@ -18,6 +18,10 @@
         AudioSessionSetProperty(kAudioSessionProperty_OverrideAudioRoute, sizeof(audioRouteOverride), &audioRouteOverride);
     } else if ([mode isEqualToString:@"speaker"]) {
         [session setCategory:AVAudioSessionCategorySoloAmbient error:&err];
+    } else if ([mode isEqualToString:@"normal"]) {
+        [session setCategory:AVAudioSessionCategorySoloAmbient error:&err];
+    } else if ([mode isEqualToString:@"ringtone"]) {
+        [session setCategory:AVAudioSessionCategorySoloAmbient error:&err];
     }
 }
 

--- a/www/audiotoggle.js
+++ b/www/audiotoggle.js
@@ -2,6 +2,8 @@ var exec = require('cordova/exec');
 
 exports.SPEAKER = 'speaker';
 exports.EARPIECE = 'earpiece';
+exports.NORMAL = 'normal';
+exports.RINGTONE = 'ringtone';
 
 exports.setAudioMode = function (mode) {
 	cordova.exec(null, null, 'AudioTogglePlugin', 'setAudioMode', [mode]);


### PR DESCRIPTION
This is for issue #1 to provide a way to switch back to MODE_NORMAL when your app is in the background or not currently using audio. If you don't switch back to MODE_NORMAL it can screw up other apps using Audio Manager by not allowing volume changes, forcing their audio through earpiece, etc.
