### PR TITLE
fix: correctly set android config

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,7 +39,7 @@
 			</feature>	
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest">
+        <config-file target="AndroidManifest.xml" parent="/*">
 			<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
         </config-file>
     </platform>


### PR DESCRIPTION
The parent needs to be set correctly, otherwise this permission is not added to the android manifest! If this is not correctly added nothing is happening on android, changing Audio output is just ignored...

Compare:
http://cordova.apache.org/docs/en/latest/guide/platforms/android/plugin.html#android-permissions